### PR TITLE
Add streamable response helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ return [
 ```php
 use Cloudstudio\Ollama\Facades\Ollama;
 
+/** @var array $response */
 $response = Ollama::agent('You are a weather expert...')
     ->prompt('Why is the sky blue?')
     ->model('llama2')
@@ -53,6 +54,7 @@ $response = Ollama::agent('You are a weather expert...')
 ### Vision Support
     
 ```php
+/** @var array $response */
 $response = Ollama::model('llava:13b')
     ->prompt('What is in this picture?')
     ->image(public_path('images/example.jpg')) 
@@ -76,6 +78,33 @@ $response = Ollama::agent('You know me really well!')
     ->chat($messages);
 
 // "You mentioned that you live in Spain."
+
+```
+
+
+### Streamable responses
+
+```php
+
+use Cloudstudio\Ollama\Facades\Ollama;
+use Illuminate\Console\BufferedConsoleOutput;
+
+/** @var \GuzzleHttp\Psr7\Response $response */
+$response = Ollama::agent('You are a snarky friend with one-line responses')
+    ->prompt("I didn't sleep much last night")
+    ->model('llama3')
+    ->options(['temperature' => 0.1])
+    ->stream(true)
+    ->ask();
+
+$output = new BufferedConsoleOutput();
+$responses = Ollama::processStream($response->getBody(), function($data) use ($output) {
+    $output->write($data['response']);
+});
+
+$output->write("\n");
+$complete = implode('', array_column($responses, 'response'));
+$output->write("<info>$complete</info>");
 
 ```
 

--- a/src/Ollama.php
+++ b/src/Ollama.php
@@ -4,6 +4,7 @@ namespace Cloudstudio\Ollama;
 
 use Cloudstudio\Ollama\Services\ModelService;
 use Cloudstudio\Ollama\Traits\MakesHttpRequests;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Storage;
 
 /**
@@ -286,7 +287,7 @@ class Ollama
     /**
      * Generates content using the specified model.
      *
-     * @return array
+     * @return array|Response
      */
     public function ask()
     {

--- a/src/Ollama.php
+++ b/src/Ollama.php
@@ -4,8 +4,10 @@ namespace Cloudstudio\Ollama;
 
 use Cloudstudio\Ollama\Services\ModelService;
 use Cloudstudio\Ollama\Traits\MakesHttpRequests;
+use Cloudstudio\Ollama\Traits\StreamHelper;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Storage;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Ollama class for integration with Laravel.
@@ -13,6 +15,7 @@ use Illuminate\Support\Facades\Storage;
 class Ollama
 {
     use MakesHttpRequests;
+    use StreamHelper;
 
     /**
      * modelService
@@ -324,5 +327,16 @@ class Ollama
             'options' => $this->options,
             'stream' => $this->stream,
         ]);
+    }
+
+
+    /**
+     * @param StreamInterface $body
+     * @param \Closure $handleJsonObject
+     * @return array
+     * @throws \Exception
+     */
+    public static function processStream(StreamInterface $body, \Closure $handleJsonObject): array {
+        return self::doProcessStream($body, $handleJsonObject);
     }
 }

--- a/src/Traits/MakesHttpRequests.php
+++ b/src/Traits/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Cloudstudio\Ollama\Traits;
 
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Http;
 use GuzzleHttp\Client;
 
@@ -13,7 +14,7 @@ trait MakesHttpRequests
      * @param string $urlSuffix
      * @param array $data
      * @param string $method (optional)
-     * @return array
+     * @return array|Response
      */
     protected function sendRequest(string $urlSuffix, array $data, string $method = 'post')
     {

--- a/src/Traits/StreamHelper.php
+++ b/src/Traits/StreamHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Cloudstudio\Ollama\Traits;
+
+use Psr\Http\Message\StreamInterface;
+
+trait StreamHelper {
+    protected function processStream(StreamInterface $body, \Closure $handleJsonObject) {
+        // Use a buffer to hold incomplete JSON object parts
+        $buffer = '';
+
+        while (!$body->eof()) {
+            $chunk = $body->read(256);
+            $buffer .= $chunk;
+
+            // Split the buffer by newline as a delimiter
+            while (($pos = strpos($buffer, "\n")) !== false) {
+                $json = substr($buffer, 0, $pos);
+                $buffer = substr($buffer, $pos + 1);
+
+                // Attempt to decode the JSON object
+                $data = json_decode($json, true);
+
+                // Check if JSON decoding was successful
+                // if so, pass the object to the handler
+                if ($data !== null) {
+                    $handleJsonObject($data);
+                } else {
+                    // If JSON decoding fails, it means this is an incomplete object,
+                    // So, we append this part back to the buffer to be processed with the next chunk
+                    $buffer = $json . "\n" . $buffer;
+                    break;
+                }
+            }
+        }
+
+        // Process any remaining data in the buffer
+        if (!empty($buffer)) {
+            $data = json_decode($buffer, true);
+            if ($data !== null) {
+                $handleJsonObject($data);
+            } else {
+                // we shouldn't ever hit this, except maybe when the ollama docker container is unexpectedly killed
+                throw new \Exception( "Incomplete JSON object remaining: " . $buffer);
+            }
+        }
+    }
+}

--- a/src/Traits/StreamHelper.php
+++ b/src/Traits/StreamHelper.php
@@ -44,7 +44,7 @@ trait StreamHelper {
                 $handleJsonObject($data);
                 $jsonObjects[] = $data;
             } else {
-                // we shouldn't ever hit this, except maybe when the ollama docker container is unexpectedly killed
+                // we shouldn't hit this, except when ollama is unexpectedly killed
                 throw new \Exception( "Incomplete JSON object remaining: " . $buffer);
             }
         }


### PR DESCRIPTION
Hey, I noticed that stream support was added in https://github.com/cloudstudio/ollama-laravel/issues/4 but without much documentation.

- I updated the return types for this change
- I added a StreamHelper trait to deal with partial stream responses
- I added an example to the readme that shows how to use the streamed response

Thanks!