### PR TITLE
Feature/authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
 # Changelog
 
 All notable changes to `ollama-laravel` will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Added support for bearer and basic authentication
+- Added configurable SSL verification
+- Added support for custom headers in configuration
+
+### Changed
+- Updated composer dependencies to support Laravel 10/11
+- Improved type safety with strict_types declaration
+- Enhanced error handling for authentication configuration

--- a/README.md
+++ b/README.md
@@ -46,11 +46,21 @@ return [
 
 ### Authentication
 
-The package supports both Basic Authentication and Bearer Token Authentication.
+> **Note:** The Ollama server itself does not include built-in authentication. The authentication features in this package are designed to work with reverse proxy setups (like Nginx, Caddy, or Apache) that add authentication in front of your Ollama server.
+
+The package supports both Basic Authentication and Bearer Token Authentication when accessing Ollama through a reverse proxy. This is particularly useful when:
+- Deploying Ollama in a production environment
+- Securing access to your Ollama instance
+- Running Ollama behind a corporate firewall
+
+Common reverse proxy setups:
+- Nginx with basic auth or token validation
+- Caddy with authentication middleware
+- Apache with auth modules
 
 #### Basic Authentication
 
-To use Basic Authentication, set the following environment variables:
+To use Basic Authentication with your reverse proxy, set the following environment variables:
 
 ```env
 OLLAMA_AUTH_TYPE=basic
@@ -188,46 +198,3 @@ $complete = implode('', array_column($responses, 'response'));
 $output->write("<info>$complete</info>");
 
 ```
-
-### Show Model Information
-
-```php
-$response = Ollama::model('Llama2')->show();
-```
-
-### Copy a Model
-
-```php
-Ollama::model('Llama2')->copy('NewModel');
-```
-
-### Delete a Model
-
-```php
-Ollama::model('Llama2')->delete();
-```
-
-### Generate Embeddings
-
-```php
-$embeddings = Ollama::model('Llama2')->embeddings('Your prompt here');
-```
-
-## Testing
-
-```bash
-pest
-```
-
-## Changelog, Contributing, and Security
-
-- [Changelog](CHANGELOG.md)
-- [Contributing](CONTRIBUTING.md)
-
-## Credits
-
-- [Toni Soriano](https://github.com/cloudstudio)
-
-## License
-
-[MIT License](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Ollama-Laravel Package
 
 Ollama-Laravel is a Laravel package that provides a seamless integration with the [Ollama API](https://github.com/jmorganca/ollama). It includes functionalities for model management, prompt generation, format setting, and more. This package is perfect for developers looking to leverage the power of the Ollama API in their Laravel applications.
@@ -30,8 +29,53 @@ return [
     'default_prompt' => env('OLLAMA_DEFAULT_PROMPT', 'Hello, how can I assist you today?'),
     'connection' => [
         'timeout' => env('OLLAMA_CONNECTION_TIMEOUT', 300),
+        'verify_ssl' => env('OLLAMA_VERIFY_SSL', true),
+        'auth' => [
+            'type' => env('OLLAMA_AUTH_TYPE', null), // 'basic' or 'bearer'
+            'username' => env('OLLAMA_AUTH_USERNAME', null),
+            'password' => env('OLLAMA_AUTH_PASSWORD', null),
+            'token' => env('OLLAMA_AUTH_TOKEN', null),
+        ],
+        'headers' => [
+            // Add any custom headers here
+            // 'X-Custom-Header' => 'value',
+        ],
     ],
 ];
+```
+
+### Authentication
+
+The package supports both Basic Authentication and Bearer Token Authentication.
+
+#### Basic Authentication
+
+To use Basic Authentication, set the following environment variables:
+
+```env
+OLLAMA_AUTH_TYPE=basic
+OLLAMA_AUTH_USERNAME=your_username
+OLLAMA_AUTH_PASSWORD=your_password
+```
+
+#### Bearer Token Authentication
+
+To use Bearer Token Authentication, set the following environment variables:
+
+```env
+OLLAMA_AUTH_TYPE=bearer
+OLLAMA_AUTH_TOKEN=your_bearer_token
+```
+
+#### Custom Headers
+
+You can add custom headers in the configuration file:
+
+```php
+'headers' => [
+    'X-Custom-Header' => 'value',
+    'Another-Header' => 'another-value',
+],
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "orchestra/testbench": "^8.8",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest": "^2.20",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"

--- a/config/ollama-laravel.php
+++ b/config/ollama-laravel.php
@@ -8,5 +8,13 @@ return [
     'default_prompt' => env('OLLAMA_DEFAULT_PROMPT', 'Hello, how can I assist you today?'),
     'connection' => [
         'timeout' => env('OLLAMA_CONNECTION_TIMEOUT', 300),
+        'verify_ssl' => env('OLLAMA_VERIFY_SSL', true),
     ],
+    'auth' => [
+        'type' => env('OLLAMA_AUTH_TYPE', null), // 'bearer' or 'basic' or null
+        'token' => env('OLLAMA_AUTH_TOKEN', null),
+        'username' => env('OLLAMA_AUTH_USERNAME', null),
+        'password' => env('OLLAMA_AUTH_PASSWORD', null),
+    ],
+    'headers' => [],
 ];

--- a/src/Traits/MakesHttpRequests.php
+++ b/src/Traits/MakesHttpRequests.php
@@ -1,13 +1,42 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cloudstudio\Ollama\Traits;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Http;
-use GuzzleHttp\Client;
+use InvalidArgumentException;
 
 trait MakesHttpRequests
 {
+    /**
+     * Get request headers including authentication if configured.
+     */
+    protected function getHeaders(): array
+    {
+        $headers = [];
+        $authType = config('ollama-laravel.auth.type');
+
+        if ($authType === 'bearer') {
+            if (!config('ollama-laravel.auth.token')) {
+                throw new InvalidArgumentException('Bearer token is required when using token authentication');
+            }
+            $headers['Authorization'] = 'Bearer ' . config('ollama-laravel.auth.token');
+        } elseif ($authType === 'basic') {
+            if (!config('ollama-laravel.auth.username') || !config('ollama-laravel.auth.password')) {
+                throw new InvalidArgumentException('Username and password are required when using basic authentication');
+            }
+            $headers['Authorization'] = 'Basic ' . base64_encode(
+                config('ollama-laravel.auth.username') . ':' . config('ollama-laravel.auth.password')
+            );
+        }
+
+        return array_merge($headers, config('ollama-laravel.headers', []));
+    }
+
     /**
      * Sends an HTTP request to the API and returns the response.
      *
@@ -15,23 +44,30 @@ trait MakesHttpRequests
      * @param array $data
      * @param string $method (optional)
      * @return array|Response
+     * @throws GuzzleException
      */
-    protected function sendRequest(string $urlSuffix, array $data, string $method = 'post')
+    protected function sendRequest(string $urlSuffix, array $data, string $method = 'post'): array|Response
     {
         $url = config('ollama-laravel.url') . $urlSuffix;
+        $headers = $this->getHeaders();
 
         if (!empty($data['stream']) && $data['stream'] === true) {
             $client = new Client();
-            $response = $client->request($method, $url, [
+            $options = [
                 'json' => $data,
                 'stream' => true,
                 'timeout' => config('ollama-laravel.connection.timeout'),
-            ]);
+                'headers' => $headers,
+                'verify' => config('ollama-laravel.connection.verify_ssl', true),
+            ];
 
-            return $response;
-        } else {
-            $response = Http::timeout(config('ollama-laravel.connection.timeout'))->$method($url, $data);
-            return $response->json();
+            return $client->request($method, $url, $options);
         }
+
+        $http = Http::withHeaders($headers)
+            ->timeout(config('ollama-laravel.connection.timeout'))
+            ->withOptions(['verify' => config('ollama-laravel.connection.verify_ssl', true)]);
+
+        return $http->$method($url, $data)->json();
     }
 }

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Cloudstudio\Ollama\Ollama;
+use Cloudstudio\Ollama\Services\ModelService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->ollama = new Ollama(new ModelService());
+
+    Http::fake([
+        '*' => Http::response(['success' => true], 200),
+    ]);
+});
+
+it('adds bearer token authentication', function () {
+    Config::set('ollama-laravel.auth.type', 'bearer');
+    Config::set('ollama-laravel.auth.token', 'test-token');
+
+    $this->ollama->model('llama2')
+        ->prompt('Test prompt')
+        ->ask();
+
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('Authorization', 'Bearer test-token');
+    });
+});
+
+it('adds basic authentication', function () {
+    Config::set('ollama-laravel.auth.type', 'basic');
+    Config::set('ollama-laravel.auth.username', 'user');
+    Config::set('ollama-laravel.auth.password', 'pass');
+
+    $this->ollama->model('llama2')
+        ->prompt('Test prompt')
+        ->ask();
+
+    Http::assertSent(function ($request) {
+        $expectedAuth = 'Basic ' . base64_encode('user:pass');
+        return $request->hasHeader('Authorization', $expectedAuth);
+    });
+});
+
+it('throws exception for missing bearer token', function () {
+    Config::set('ollama-laravel.auth.type', 'bearer');
+    Config::set('ollama-laravel.auth.token', null);
+
+    expect(fn () => $this->ollama->model('llama2')
+        ->prompt('Test prompt')
+        ->ask()
+    )->toThrow(
+        InvalidArgumentException::class,
+        'Bearer token is required when using token authentication'
+    );
+});
+
+it('throws exception for missing basic auth credentials', function () {
+    Config::set('ollama-laravel.auth.type', 'basic');
+    Config::set('ollama-laravel.auth.username', null);
+    Config::set('ollama-laravel.auth.password', null);
+
+    expect(fn () => $this->ollama->model('llama2')
+        ->prompt('Test prompt')
+        ->ask()
+    )->toThrow(
+        InvalidArgumentException::class,
+        'Username and password are required when using basic authentication'
+    );
+});
+
+it('works without authentication', function () {
+    Config::set('ollama-laravel.auth.type', null);
+
+    $this->ollama->model('llama2')
+        ->prompt('Test prompt')
+        ->ask();
+
+    Http::assertSent(function ($request) {
+        return !$request->hasHeader('Authorization');
+    });
+});


### PR DESCRIPTION
As described in the issue https://github.com/cloudstudio/ollama-laravel/issues/26. Here is the pull request with following changes/additions.

feat: add authentication support and improve HTTP client configuration

- Add bearer and basic authentication support
- Make SSL verification configurable
- Allow custom headers in configuration

- Update composer dependencies for Laravel 11 compatibility
 - Received errors like 
 ```
 Your requirements could not be resolved to an installable set of packages.
 ```
 
 and 
 ```
 Root composer.json requires illuminate/contracts ^11.0 -> satisfiable by illuminate/contracts[v11.0.0, ..., 11.x-dev], laravel/framework[v11.0.0, ..., 11.x-dev].
 ```

- Improve type safety with strict_types declaration
- Enhance error handling for authentication configuration

docs: update documentation for authentication features

- Add authentication section to README with examples
- Document basic auth and bearer token configuration
- Add custom headers configuration examples
- Update CHANGELOG with recent authentication features
- Include SSL verification configuration details
-  add note for reverse proxy and hints for possible reverse proxies to help readers to explore possible options to add authentication to Ollama