### PR TITLE
Fix return types and type hinting

### DIFF
--- a/config/ollama-laravel.php
+++ b/config/ollama-laravel.php
@@ -7,7 +7,7 @@ return [
     'url' => env('OLLAMA_URL', 'http://127.0.0.1:11434'),
     'default_prompt' => env('OLLAMA_DEFAULT_PROMPT', 'Hello, how can I assist you today?'),
     'connection' => [
-        'timeout' => env('OLLAMA_CONNECTION_TIMEOUT', 300),
+        'timeout' => (int)env('OLLAMA_CONNECTION_TIMEOUT', 300),
         'verify_ssl' => env('OLLAMA_VERIFY_SSL', true),
     ],
     'auth' => [

--- a/src/Facades/Ollama.php
+++ b/src/Facades/Ollama.php
@@ -3,14 +3,15 @@
 namespace Cloudstudio\Ollama\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Cloudstudio\Ollama\Ollama as OllamaClient;
 
 /**
- * @see \Cloudstudio\Ollama\Ollama
+ * @see OllamaClient
  */
-class Ollama extends Facade
-{
-    protected static function getFacadeAccessor()
+class Ollama extends Facade {
+
+    protected static function getFacadeAccessor(): string
     {
-        return \Cloudstudio\Ollama\Ollama::class;
+        return OllamaClient::class;
     }
 }

--- a/src/Ollama.php
+++ b/src/Ollama.php
@@ -2,12 +2,14 @@
 
 namespace Cloudstudio\Ollama;
 
+use Closure;
 use Cloudstudio\Ollama\Services\ModelService;
 use Cloudstudio\Ollama\Traits\MakesHttpRequests;
 use Cloudstudio\Ollama\Traits\StreamHelper;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
-use Illuminate\Support\Facades\Storage;
 use Psr\Http\Message\StreamInterface;
+use Exception;
 
 /**
  * Ollama class for integration with Laravel.
@@ -22,91 +24,91 @@ class Ollama
      *
      * @var mixed
      */
-    protected $modelService;
+    protected ModelService $modelService;
 
     /**
      * selectedModel
      *
      * @var mixed
      */
-    protected $selectedModel;
+    protected string $selectedModel;
 
     /**
      * model
      *
      * @var mixed
      */
-    protected $model;
+    protected string $model;
 
     /**
      * prompt
      *
      * @var mixed
      */
-    protected $prompt;
+    protected ?string $prompt = null;
 
     /**
      * format
      *
      * @var mixed
      */
-    protected $format;
+    protected ?string $format = null;
 
     /**
      * options
      *
      * @var mixed
      */
-    protected $options;
+    protected ?array $options = null;
 
     /**
      * options
      *
      * @var mixed
      */
-    protected $tools;
+    protected ?array $tools = null;
 
     /**
      * stream
      *
      * @var bool
      */
-    protected $stream = false;
+    protected bool $stream = false;
 
     /**
      * raw
      *
      * @var mixed
      */
-    protected $raw;
+    protected ?bool $raw = null;
 
     /**
      * agent
      *
      * @var mixed
      */
-    protected $agent;
+    protected ?string $agent = null;
 
     /**
      * Base64 encoded image.
      *
      * @var string|null
      */
-    protected $image = null;
+    protected ?string $image = null;
 
     /**
      * Base64 encoded images.
      *
      * @var array|null
      */
-    protected $images = [];
+    protected ?array $images = [];
 
     /**
      * keep alive
      *
      * @ var mixed
      */
-    protected $keepAlive = "5m";
+    protected string $keepAlive = "5m";
 
     /**
      * Ollama class constructor.
@@ -114,7 +116,8 @@ class Ollama
     public function __construct(ModelService $modelService)
     {
         $this->modelService = $modelService;
-        $this->model = config('ollama-laravel.model');
+        $this->model = config('ollama-laravel.model', 'llama2');
+        $this->selectedModel = $this->model;
     }
 
     /**
@@ -123,7 +126,7 @@ class Ollama
      * @param string $agent
      * @return $this
      */
-    public function agent(string $agent)
+    public function agent(string $agent): Ollama
     {
         $this->agent = $agent;
         return $this;
@@ -135,7 +138,7 @@ class Ollama
      * @param string $prompt
      * @return $this
      */
-    public function prompt(string $prompt)
+    public function prompt(string $prompt): Ollama
     {
         $this->prompt = $prompt;
         return $this;
@@ -147,7 +150,7 @@ class Ollama
      * @param string $model
      * @return $this
      */
-    public function model(string $model)
+    public function model(string $model): Ollama
     {
         $this->selectedModel = $model;
         $this->model = $model;
@@ -160,7 +163,7 @@ class Ollama
      * @param string $format
      * @return $this
      */
-    public function format(string $format)
+    public function format(string $format): Ollama
     {
         $this->format = $format;
         return $this;
@@ -172,7 +175,7 @@ class Ollama
      * @param array $options
      * @return $this
      */
-    public function options(array $options = [])
+    public function options(array $options = []): Ollama
     {
         $this->options = $options;
         return $this;
@@ -184,7 +187,7 @@ class Ollama
      * @param bool $stream
      * @return $this
      */
-    public function stream(bool $stream = false)
+    public function stream(bool $stream = false): Ollama
     {
         $this->stream = $stream;
         return $this;
@@ -196,7 +199,7 @@ class Ollama
      * @param array $tools
      * @return $this
      */
-    public function tools(array $tools = [])
+    public function tools(array $tools = []): Ollama
     {
         $this->tools = $tools;
         return $this;
@@ -208,7 +211,7 @@ class Ollama
      * @param bool $raw
      * @return $this
      */
-    public function raw(bool $raw)
+    public function raw(bool $raw): Ollama
     {
         $this->raw = $raw;
         return $this;
@@ -220,7 +223,7 @@ class Ollama
      * @param string $keepAlive
      * @return $this
      */
-    public function keepAlive(string $keepAlive)
+    public function keepAlive(string $keepAlive): Ollama
     {
         $this->keepAlive = $keepAlive;
         return $this;
@@ -230,8 +233,9 @@ class Ollama
      * Lists available local models.
      *
      * @return array
+     * @throws GuzzleException
      */
-    public function models()
+    public function models(): array
     {
         return $this->modelService->listLocalModels();
     }
@@ -240,8 +244,9 @@ class Ollama
      * Shows information about the selected model.
      *
      * @return array
+     * @throws GuzzleException
      */
-    public function show()
+    public function show(): array
     {
         return $this->modelService->showModelInformation($this->selectedModel);
     }
@@ -251,9 +256,9 @@ class Ollama
      *
      * @param string $destination
      * @return $this
-     * @throws \Exception
+     * @throws Exception|GuzzleException
      */
-    public function copy(string $destination)
+    public function copy(string $destination): Ollama
     {
         $this->modelService->copyModel($this->selectedModel, $destination);
         return $this;
@@ -263,9 +268,9 @@ class Ollama
      * Deletes a model.
      *
      * @return $this
-     * @throws \Exception
+     * @throws Exception|GuzzleException
      */
-    public function delete()
+    public function delete(): Ollama
     {
         $this->modelService->deleteModel($this->selectedModel);
         return $this;
@@ -275,9 +280,9 @@ class Ollama
      * Pulls a model.
      *
      * @return $this
-     * @throws \Exception
+     * @throws Exception|GuzzleException
      */
-    public function pull()
+    public function pull(): Ollama
     {
         $this->modelService->pullModel($this->selectedModel);
         return $this;
@@ -288,12 +293,12 @@ class Ollama
      *
      * @param string $imagePath
      * @return $this
-     * @throws \Exception
+     * @throws Exception
      */
-    public function image(string $imagePath)
+    public function image(string $imagePath): Ollama
     {
         if (!file_exists($imagePath)) {
-            throw new \Exception("Image file does not exist: $imagePath");
+            throw new Exception("Image file does not exist: $imagePath");
         }
 
         $this->image = base64_encode(file_get_contents($imagePath));
@@ -305,13 +310,13 @@ class Ollama
      *
      * @param array $imagePaths
      * @return $this
-     * @throws \Exception
+     * @throws Exception
      */
-    public function images(array $imagePaths)
+    public function images(array $imagePaths): Ollama
     {
         foreach ($imagePaths as $imagePath) {
             if (!file_exists($imagePath)) {
-                throw new \Exception("Image file does not exist: $imagePath");
+                throw new Exception("Image file does not exist: $imagePath");
             }
 
             $this->images[] = base64_encode(file_get_contents($imagePath));
@@ -320,15 +325,15 @@ class Ollama
         return $this;
     }
 
-
     /**
      * Generates embeddings from the selected model.
      *
      * @param string $prompt
      * @return array
-     * @throws \Exception
+     * @throws Exception
+     * @throws GuzzleException
      */
-    public function embeddings(string $prompt)
+    public function embeddings(string $prompt): array
     {
         return $this->modelService->generateEmbeddings($this->selectedModel, $prompt);
     }
@@ -337,8 +342,9 @@ class Ollama
      * Generates content using the specified model.
      *
      * @return array|Response
+     * @throws GuzzleException
      */
-    public function ask()
+    public function ask(): array|Response
     {
         $requestData = [
             'model' => $this->model,
@@ -367,9 +373,10 @@ class Ollama
      * Generates a chat completion using the specified model and conversation.
      *
      * @param array $conversation
-     * @return array
+     * @return array|Response
+     * @throws GuzzleException
      */
-    public function chat(array $conversation)
+    public function chat(array $conversation): array|Response
     {
         return $this->sendRequest('/api/chat', [
             'model' => $this->model,
@@ -384,11 +391,11 @@ class Ollama
 
     /**
      * @param StreamInterface $body
-     * @param \Closure $handleJsonObject
+     * @param Closure $handleJsonObject
      * @return array
-     * @throws \Exception
+     * @throws Exception
      */
-    public static function processStream(StreamInterface $body, \Closure $handleJsonObject): array {
+    public static function processStream(StreamInterface $body, Closure $handleJsonObject): array {
         return self::doProcessStream($body, $handleJsonObject);
     }
 }

--- a/src/Ollama.php
+++ b/src/Ollama.php
@@ -14,57 +14,57 @@ use Exception;
 /**
  * Ollama class for integration with Laravel.
  */
-class Ollama
-{
+class Ollama {
+
     use MakesHttpRequests;
     use StreamHelper;
 
     /**
      * modelService
      *
-     * @var mixed
+     * @var ModelService
      */
     protected ModelService $modelService;
 
     /**
      * selectedModel
      *
-     * @var mixed
+     * @var string
      */
     protected string $selectedModel;
 
     /**
      * model
      *
-     * @var mixed
+     * @var string
      */
     protected string $model;
 
     /**
      * prompt
      *
-     * @var mixed
+     * @var null | string
      */
     protected ?string $prompt = null;
 
     /**
      * format
      *
-     * @var mixed
+     * @var null | string
      */
     protected ?string $format = null;
 
     /**
      * options
      *
-     * @var mixed
+     * @var null | array
      */
     protected ?array $options = null;
 
     /**
      * options
      *
-     * @var mixed
+     * @var null | array
      */
     protected ?array $tools = null;
 
@@ -78,35 +78,35 @@ class Ollama
     /**
      * raw
      *
-     * @var mixed
+     * @var null | bool
      */
     protected ?bool $raw = null;
 
     /**
      * agent
      *
-     * @var mixed
+     * @var null | string
      */
     protected ?string $agent = null;
 
     /**
      * Base64 encoded image.
      *
-     * @var string|null
+     * @var null | string
      */
     protected ?string $image = null;
 
     /**
      * Base64 encoded images.
      *
-     * @var array|null
+     * @var null | array
      */
     protected ?array $images = [];
 
     /**
      * keep alive
      *
-     * @ var mixed
+     * @var string
      */
     protected string $keepAlive = "5m";
 
@@ -129,6 +129,7 @@ class Ollama
     public function agent(string $agent): Ollama
     {
         $this->agent = $agent;
+
         return $this;
     }
 
@@ -141,6 +142,7 @@ class Ollama
     public function prompt(string $prompt): Ollama
     {
         $this->prompt = $prompt;
+
         return $this;
     }
 
@@ -154,6 +156,7 @@ class Ollama
     {
         $this->selectedModel = $model;
         $this->model = $model;
+
         return $this;
     }
 
@@ -166,6 +169,7 @@ class Ollama
     public function format(string $format): Ollama
     {
         $this->format = $format;
+
         return $this;
     }
 
@@ -178,6 +182,7 @@ class Ollama
     public function options(array $options = []): Ollama
     {
         $this->options = $options;
+
         return $this;
     }
 
@@ -190,6 +195,7 @@ class Ollama
     public function stream(bool $stream = false): Ollama
     {
         $this->stream = $stream;
+
         return $this;
     }
 
@@ -202,6 +208,7 @@ class Ollama
     public function tools(array $tools = []): Ollama
     {
         $this->tools = $tools;
+
         return $this;
     }
 
@@ -214,6 +221,7 @@ class Ollama
     public function raw(bool $raw): Ollama
     {
         $this->raw = $raw;
+
         return $this;
     }
 
@@ -226,6 +234,7 @@ class Ollama
     public function keepAlive(string $keepAlive): Ollama
     {
         $this->keepAlive = $keepAlive;
+
         return $this;
     }
 
@@ -261,6 +270,7 @@ class Ollama
     public function copy(string $destination): Ollama
     {
         $this->modelService->copyModel($this->selectedModel, $destination);
+
         return $this;
     }
 
@@ -273,6 +283,7 @@ class Ollama
     public function delete(): Ollama
     {
         $this->modelService->deleteModel($this->selectedModel);
+
         return $this;
     }
 
@@ -285,6 +296,7 @@ class Ollama
     public function pull(): Ollama
     {
         $this->modelService->pullModel($this->selectedModel);
+
         return $this;
     }
 
@@ -302,6 +314,7 @@ class Ollama
         }
 
         $this->image = base64_encode(file_get_contents($imagePath));
+
         return $this;
     }
 
@@ -388,14 +401,14 @@ class Ollama
         ]);
     }
 
-
     /**
      * @param StreamInterface $body
      * @param Closure $handleJsonObject
      * @return array
      * @throws Exception
      */
-    public static function processStream(StreamInterface $body, Closure $handleJsonObject): array {
+    public static function processStream(StreamInterface $body, Closure $handleJsonObject): array
+    {
         return self::doProcessStream($body, $handleJsonObject);
     }
 }

--- a/src/OllamaServiceProvider.php
+++ b/src/OllamaServiceProvider.php
@@ -2,10 +2,11 @@
 
 namespace Cloudstudio\Ollama;
 
+use Cloudstudio\Ollama\Services\ModelService;
+use Illuminate\Foundation\Application;
+use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Cloudstudio\Ollama\Commands\OllamaCommand;
-use Cloudstudio\Ollama\Ollama;
 
 class OllamaServiceProvider extends PackageServiceProvider
 {
@@ -25,13 +26,20 @@ class OllamaServiceProvider extends PackageServiceProvider
      * Method register
      *
      * @return void
+     * @throws InvalidPackage
      */
-    public function register()
+    public function register(): void
     {
         parent::register();
 
-        $this->app->singleton(OllamaService::class, function ($app) {
-            return new Ollama();
+        $this->app->singleton(ModelService::class, function () {
+            return new ModelService();
+        });
+
+        $this->app->singleton(Ollama::class, function (Application $app) {
+            return new Ollama(
+                $app->make(ModelService::class)
+            );
         });
     }
 }

--- a/src/Services/ModelService.php
+++ b/src/Services/ModelService.php
@@ -3,6 +3,7 @@
 namespace Cloudstudio\Ollama\Services;
 
 use Cloudstudio\Ollama\Traits\MakesHttpRequests;
+use GuzzleHttp\Exception\GuzzleException;
 
 class ModelService
 {
@@ -12,7 +13,7 @@ class ModelService
     /**
      * Base URL for the API.
      */
-    protected $baseUrl;
+    protected string $baseUrl;
 
     public function __construct()
     {
@@ -23,8 +24,9 @@ class ModelService
      * List local models.
      *
      * @return array
+     * @throws GuzzleException
      */
-    public function listLocalModels()
+    public function listLocalModels(): array
     {
         return $this->sendRequest('/api/tags', [], 'get');
     }
@@ -34,8 +36,9 @@ class ModelService
      *
      * @param string $modelName
      * @return array
+     * @throws GuzzleException
      */
-    public function showModelInformation(string $modelName)
+    public function showModelInformation(string $modelName): array
     {
         return $this->sendRequest('/api/show', ['name' => $modelName]);
     }
@@ -46,8 +49,9 @@ class ModelService
      * @param string $source
      * @param string $destination
      * @return array
+     * @throws GuzzleException
      */
-    public function copyModel(string $source, string $destination)
+    public function copyModel(string $source, string $destination): array
     {
         return $this->sendRequest('/api/copy', [
             'source' => $source,
@@ -60,8 +64,9 @@ class ModelService
      *
      * @param string $modelName
      * @return array
+     * @throws GuzzleException
      */
-    public function deleteModel(string $modelName)
+    public function deleteModel(string $modelName): array
     {
         return $this->sendRequest('/api/delete', ['name' => $modelName], 'delete');
     }
@@ -71,8 +76,9 @@ class ModelService
      *
      * @param string $modelName
      * @return array
+     * @throws GuzzleException
      */
-    public function pullModel(string $modelName)
+    public function pullModel(string $modelName): array
     {
         return $this->sendRequest('/api/pull', ['name' => $modelName]);
     }
@@ -83,8 +89,9 @@ class ModelService
      * @param string $modelName
      * @param string $prompt
      * @return array
+     * @throws GuzzleException
      */
-    public function generateEmbeddings(string $modelName, string $prompt)
+    public function generateEmbeddings(string $modelName, string $prompt): array
     {
         return $this->sendRequest('/api/embeddings', [
             'model' => $modelName,

--- a/src/Traits/StreamHelper.php
+++ b/src/Traits/StreamHelper.php
@@ -3,8 +3,13 @@
 namespace Cloudstudio\Ollama\Traits;
 
 use Psr\Http\Message\StreamInterface;
+use Exception;
 
 trait StreamHelper {
+
+    /**
+     * @throws Exception
+     */
     protected static function doProcessStream(StreamInterface $body, \Closure $handleJsonObject): array {
         // Use a buffer to hold incomplete JSON object parts
         $buffer = '';
@@ -45,7 +50,7 @@ trait StreamHelper {
                 $jsonObjects[] = $data;
             } else {
                 // we shouldn't hit this, except when ollama is unexpectedly killed
-                throw new \Exception( "Incomplete JSON object remaining: " . $buffer);
+                throw new Exception( "Incomplete JSON object remaining: " . $buffer);
             }
         }
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -4,12 +4,11 @@ use Cloudstudio\Ollama\Ollama;
 use Cloudstudio\Ollama\Services\ModelService;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
-use InvalidArgumentException;
 
 beforeEach(function () {
     Config::set('ollama-laravel.model', 'llama2');
     $this->ollama = new Ollama(new ModelService());
-    
+
     Http::fake([
         '*' => Http::response(['success' => true], 200),
     ]);

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -4,10 +4,12 @@ use Cloudstudio\Ollama\Ollama;
 use Cloudstudio\Ollama\Services\ModelService;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
 
 beforeEach(function () {
+    Config::set('ollama-laravel.model', 'llama2');
     $this->ollama = new Ollama(new ModelService());
-
+    
     Http::fake([
         '*' => Http::response(['success' => true], 200),
     ]);
@@ -17,7 +19,7 @@ it('adds bearer token authentication', function () {
     Config::set('ollama-laravel.auth.type', 'bearer');
     Config::set('ollama-laravel.auth.token', 'test-token');
 
-    $this->ollama->model('llama2')
+    $this->ollama
         ->prompt('Test prompt')
         ->ask();
 
@@ -31,7 +33,7 @@ it('adds basic authentication', function () {
     Config::set('ollama-laravel.auth.username', 'user');
     Config::set('ollama-laravel.auth.password', 'pass');
 
-    $this->ollama->model('llama2')
+    $this->ollama
         ->prompt('Test prompt')
         ->ask();
 
@@ -45,7 +47,7 @@ it('throws exception for missing bearer token', function () {
     Config::set('ollama-laravel.auth.type', 'bearer');
     Config::set('ollama-laravel.auth.token', null);
 
-    expect(fn () => $this->ollama->model('llama2')
+    expect(fn () => $this->ollama
         ->prompt('Test prompt')
         ->ask()
     )->toThrow(
@@ -59,7 +61,7 @@ it('throws exception for missing basic auth credentials', function () {
     Config::set('ollama-laravel.auth.username', null);
     Config::set('ollama-laravel.auth.password', null);
 
-    expect(fn () => $this->ollama->model('llama2')
+    expect(fn () => $this->ollama
         ->prompt('Test prompt')
         ->ask()
     )->toThrow(
@@ -71,7 +73,7 @@ it('throws exception for missing basic auth credentials', function () {
 it('works without authentication', function () {
     Config::set('ollama-laravel.auth.type', null);
 
-    $this->ollama->model('llama2')
+    $this->ollama
         ->prompt('Test prompt')
         ->ask();
 


### PR DESCRIPTION
While working in the last PR I have noticed that my IDE was complaining about type hintings.
I see that the package was created with the help of the spatie package tool. It looks like that the package tool did not generate correct type hinting. So I have done it manually.

I improved the type safety and service registration.

- Implemented proper type hints and return types across the Ollama class to catch 
  potential type-related issues at compile time rather than runtime
- Fixed service provider registration with correct dependency injection pattern, 
  making the code more maintainable and testable
- Added ModelService singleton registration to ensure consistent instance usage
- Replaced OllamaService with the correct Ollama class name for better clarity
- Leveraged PHP 8.2's strict typing to prevent type coercion issues
- Initialized nullable properties with explicit null values to prevent undefined 
  property warnings
- Cleaned up imports for better code organization

The PR will help to:
- Provide better IDE support and static analysis
- Catch type-related bugs earlier in the development cycle
- Make the codebase more maintainable and self-documenting
- Improve overall code reliability and developer experience

@cloudstudio FYI