### PR TITLE
Add support for Laravel 12.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/contracts": "^11.0",
+        "illuminate/contracts": "^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {


### PR DESCRIPTION
## The problem

When you run `composer require cloudstudio/ollama-laravel` in a Laravel 12.x project, you will get the composer error:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires cloudstudio/ollama-laravel * -> satisfiable by cloudstudio/ollama-laravel[1.0.0, ..., v1.1.3].
    - cloudstudio/ollama-laravel[1.0.0, ..., v1.0.5] require illuminate/contracts ^10.0 -> found illuminate/contracts[v10.0.0, ..., v10.48.28] but these were not loaded, likely because it conflicts with another require.
    - cloudstudio/ollama-laravel[v1.0.6, ..., v1.1.3] require illuminate/contracts ^11.0 -> found illuminate/contracts[v11.0.0, ..., v11.44.0] but these were not loaded, likely because it conflicts with another require.
```

## The solution

This PR resolves that error by allowing `illuminate/contracts:12.0.1`.

```bash
$ composer why illuminate/contracts
laravel/framework v12.0.1 replaces illuminate/contracts (self.version)
```