### PR TITLE
Fix: Add missing keep_alive parameter to chat method

### DIFF
--- a/src/Ollama.php
+++ b/src/Ollama.php
@@ -378,6 +378,7 @@ class Ollama
             'options' => $this->options,
             'stream' => $this->stream,
             'tools' => $this->tools,
+            'keep_alive' => $this->keepAlive,
         ]);
     }
 


### PR DESCRIPTION
- Resolves issue #39
- The keep_alive parameter was already implemented as a property and setter method
- But was missing from the chat() method request payload
- Now properly passes keep_alive to the Ollama API for chat completions