### PR TITLE
refactor: Improve keepAlive implementation with better defaults and c…

### DIFF
--- a/config/ollama-laravel.php
+++ b/config/ollama-laravel.php
@@ -6,6 +6,19 @@ return [
     'model' => env('OLLAMA_MODEL', 'llama2'),
     'url' => env('OLLAMA_URL', 'http://127.0.0.1:11434'),
     'default_prompt' => env('OLLAMA_DEFAULT_PROMPT', 'Hello, how can I assist you today?'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Keep Alive Duration
+    |--------------------------------------------------------------------------
+    |
+    | Controls how long models stay loaded in memory after a request.
+    | Set to null to use the Ollama server's default configuration.
+    | Examples: '5m' (5 minutes), '1h' (1 hour), '30s' (30 seconds)
+    |
+    */
+    'keep_alive' => env('OLLAMA_KEEP_ALIVE', null),
+
     'connection' => [
         'timeout' => env('OLLAMA_CONNECTION_TIMEOUT', 300),
     ],


### PR DESCRIPTION
…onfiguration

This PR addresses issue #41 with an improved solution that provides better flexibility and follows Laravel best practices.

Changes:
- Set keepAlive default to null instead of "5m" to respect server configuration by default
- Add OLLAMA_KEEP_ALIVE environment variable support
- Add keep_alive configuration option in config/ollama-laravel.php
- Improve PHPDoc documentation with usage examples
- Add comprehensive tests for keepAlive behavior
- Update README with detailed keepAlive usage documentation

Benefits over the original PR #42:
- Users get server defaults by default (respects OLLAMA_KEEP_ALIVE env var on server)
- More flexible: can be configured at app level (config), environment level (.env), or per-request (->keepAlive())
- Better documented with clear examples
- Fully tested with unit tests covering all scenarios
- Backward compatible: existing code continues to work

Fixes #41