### PR TITLE
feat: Add think parameter for reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Ollama-Laravel is a Laravel package that provides seamless integration with the 
 - **Text Generation**: Generate content with customizable prompts and models
 - **Vision Analysis**: Analyze images using multimodal models
 - **Chat Completion**: Build conversational AI with message history
+- **Thinking/Reasoning**: Access model reasoning with thinking models (Qwen 3, DeepSeek R1, etc.)
 - **Function Calling**: Execute tools and functions through AI
 - **Streaming Responses**: Real-time response streaming
 - **Model Management**: List, copy, delete, and pull models
@@ -189,6 +190,55 @@ function calculateTotal($items) {
 
 $response = Ollama::model('codellama')
     ->chat($messages);
+```
+
+### 🧠 Thinking/Reasoning Models
+
+Ollama supports thinking models like Qwen 3, DeepSeek R1, and others that can show their reasoning process.
+
+#### Enable Thinking Output
+```php
+$response = Ollama::model('qwen3')
+    ->prompt('What is the square root of 144 and why?')
+    ->think()
+    ->ask();
+
+// Access the reasoning process
+echo $response['thinking'];  // Model's step-by-step reasoning
+echo $response['response'];  // Final answer
+```
+
+#### Thinking with Chat
+```php
+$messages = [
+    ['role' => 'user', 'content' => 'Solve this step by step: If x + 5 = 12, what is x?']
+];
+
+$response = Ollama::model('deepseek-r1')
+    ->think()
+    ->chat($messages);
+
+// Access thinking from chat response
+echo $response['message']['thinking'];  // Reasoning steps
+echo $response['message']['content'];   // Final answer
+```
+
+#### Thinking Levels (for supported models like GPT-OSS)
+```php
+// Some models support thinking levels: "low", "medium", "high"
+$response = Ollama::model('gpt-oss')
+    ->prompt('Explain quantum entanglement')
+    ->think('high')  // Maximum reasoning depth
+    ->ask();
+```
+
+#### Disable Thinking
+```php
+// Explicitly disable thinking output
+$response = Ollama::model('qwen3')
+    ->prompt('Quick answer: What is 2+2?')
+    ->think(false)
+    ->ask();
 ```
 
 ### 🔧 Function Calling / Tools

--- a/src/Ollama.php
+++ b/src/Ollama.php
@@ -110,6 +110,14 @@ class Ollama
     protected $keepAlive = null;
 
     /**
+     * Enables thinking/reasoning output for supported models.
+     * Can be a boolean or a string level ("low", "medium", "high") for models like GPT-OSS.
+     *
+     * @var bool|string|null
+     */
+    protected $think = null;
+
+    /**
      * Ollama class constructor.
      */
     public function __construct(ModelService $modelService)
@@ -230,6 +238,27 @@ class Ollama
     public function keepAlive(?string $keepAlive)
     {
         $this->keepAlive = $keepAlive;
+        return $this;
+    }
+
+    /**
+     * Enables thinking/reasoning output for supported models (Qwen 3, DeepSeek R1, etc.).
+     *
+     * When enabled, the response will include the model's reasoning process in a separate field:
+     * - For chat: response['message']['thinking']
+     * - For generate: response['thinking']
+     *
+     * Examples:
+     * - think() or think(true) - Enable thinking output
+     * - think(false) - Disable thinking output
+     * - think('high') - Set thinking level (for models like GPT-OSS that support levels)
+     *
+     * @param bool|string $think Boolean to enable/disable, or string level ("low", "medium", "high")
+     * @return $this
+     */
+    public function think(bool|string $think = true)
+    {
+        $this->think = $think;
         return $this;
     }
 
@@ -361,6 +390,10 @@ class Ollama
             $requestData['keep_alive'] = $this->keepAlive;
         }
 
+        if ($this->think !== null) {
+            $requestData['think'] = $this->think;
+        }
+
         if ($this->image) {
             $requestData['images'] = [$this->image];
         }
@@ -392,6 +425,10 @@ class Ollama
 
         if ($this->keepAlive !== null) {
             $requestData['keep_alive'] = $this->keepAlive;
+        }
+
+        if ($this->think !== null) {
+            $requestData['think'] = $this->think;
         }
 
         return $this->sendRequest('/api/chat', $requestData);

--- a/tests/OllamaTest.php
+++ b/tests/OllamaTest.php
@@ -22,6 +22,7 @@ it('sets properties correctly and returns instance', function ($method, $value) 
     'options' => ['options', ['temperature' => 0.7]],
     'stream' => ['stream', true],
     'raw' => ['raw', true],
+    'think' => ['think', true],
 ]);
 
 it('correctly handles format as string type', function () {
@@ -186,5 +187,76 @@ it('includes keep_alive in request when set', function () {
     Http::assertSent(function ($request) {
         $body = json_decode($request->body(), true);
         return isset($body['keep_alive']) && $body['keep_alive'] === '20m';
+    });
+});
+
+it('sets think correctly with boolean and returns instance', function () {
+    expect($this->ollama->think(true))->toBeInstanceOf(Ollama::class);
+});
+
+it('sets think correctly with string level and returns instance', function () {
+    $ollama = $this->ollama->think('high');
+
+    $reflection = new ReflectionClass($ollama);
+    $property = $reflection->getProperty('think');
+    $property->setAccessible(true);
+    $value = $property->getValue($ollama);
+
+    expect($value)->toBe('high');
+    expect($ollama)->toBeInstanceOf(Ollama::class);
+});
+
+it('defaults think to true when called without arguments', function () {
+    $ollama = $this->ollama->think();
+
+    $reflection = new ReflectionClass($ollama);
+    $property = $reflection->getProperty('think');
+    $property->setAccessible(true);
+    $value = $property->getValue($ollama);
+
+    expect($value)->toBeTrue();
+});
+
+it('does not include think in request when null', function () {
+    Http::fake();
+
+    $this->ollama->prompt('test')->ask();
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+        return !array_key_exists('think', $body);
+    });
+});
+
+it('includes think in ask request when set to true', function () {
+    Http::fake();
+
+    $this->ollama->think(true)->prompt('test')->ask();
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+        return isset($body['think']) && $body['think'] === true;
+    });
+});
+
+it('includes think in chat request when set', function () {
+    Http::fake();
+
+    $this->ollama->think(true)->chat([['role' => 'user', 'content' => 'test']]);
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+        return isset($body['think']) && $body['think'] === true;
+    });
+});
+
+it('includes think level in request when set to string', function () {
+    Http::fake();
+
+    $this->ollama->think('medium')->prompt('test')->ask();
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+        return isset($body['think']) && $body['think'] === 'medium';
     });
 });


### PR DESCRIPTION
Add support for the `think` parameter that enables thinking/reasoning output for supported models like Qwen 3, DeepSeek R1, and GPT-OSS.

- Add `think()` fluent method accepting bool or string level
- Include think parameter in both ask() and chat() requests
- Add comprehensive tests for the new functionality
- Update README with documentation and examples

Closes #44